### PR TITLE
MSR improvements

### DIFF
--- a/src/caffe/layers/base_conv_layer.cpp
+++ b/src/caffe/layers/base_conv_layer.cpp
@@ -82,8 +82,9 @@ void BaseConvolutionLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
     // output channels x input channels per-group x kernel height x kernel width
     this->blobs_[0].reset(new Blob<Dtype>(
         conv_out_channels_, conv_in_channels_ / group_, kernel_h_, kernel_w_));
-    shared_ptr<Filler<Dtype> > weight_filler(GetFiller<Dtype>(
-        this->layer_param_.convolution_param().weight_filler()));
+    FillerParameter wf_params =  this->layer_param_.convolution_param().weight_filler();
+    wf_params.set_layer_type(FillerParameter_FillerLayerType_CONVOLUTION);
+    shared_ptr<Filler<Dtype> > weight_filler(GetFiller<Dtype>(wf_params));
     weight_filler->Fill(this->blobs_[0].get());
     // If necessary, initialize and fill the biases:
     // 1 x 1 x 1 x output channels

--- a/src/caffe/layers/inner_product_layer.cpp
+++ b/src/caffe/layers/inner_product_layer.cpp
@@ -28,8 +28,9 @@ void InnerProductLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
     // Intialize the weight
     this->blobs_[0].reset(new Blob<Dtype>(1, 1, N_, K_));
     // fill the weights
-    shared_ptr<Filler<Dtype> > weight_filler(GetFiller<Dtype>(
-        this->layer_param_.inner_product_param().weight_filler()));
+    FillerParameter wf_params =  this->layer_param_.inner_product_param().weight_filler();
+    wf_params.set_layer_type(FillerParameter_FillerLayerType_INNER_PRODUCT);
+    shared_ptr<Filler<Dtype> > weight_filler(GetFiller<Dtype>(wf_params));
     weight_filler->Fill(this->blobs_[0].get());
     // If necessary, intiialize and fill the bias term
     if (bias_term_) {

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -45,6 +45,16 @@ message FillerParameter {
   // both (by averaging)
   optional bool fan_in = 8 [default = true];
   optional bool fan_out = 9 [default = false];
+  optional float negative_slope = 10 [default = 0.0];
+  // negative slope of successive relu, for msr filler
+  optional float scale = 11 [default = 1.0];
+  // weights scale for msr filler
+  optional FillerLayerType layer_type = 12 [default = NONE];
+  enum FillerLayerType { // type of layer for msr filler
+    NONE = 0;
+    INNER_PRODUCT = 1;// blob(1,1,w,h),  w     -> out_num, h     -> in_num
+    CONVOLUTION = 2;  // blob(n,c,w,h),  n*w*h -> out_num, c*w*h -> in_num
+  }
 }
 
 message NetParameter {

--- a/src/caffe/test/test_filler.cpp
+++ b/src/caffe/test/test_filler.cpp
@@ -147,18 +147,46 @@ class MSRFillerTest : public ::testing::Test {
  protected:
   MSRFillerTest()
       : blob_(new Blob<Dtype>(1000, 2, 4, 5)),
+        blob_1x1xhxw(new Blob<Dtype>(1, 1, 123, 234)),
         filler_param_() {
   }
-  virtual void test_params(bool fan_in, bool fan_out, Dtype n) {
+  virtual void test_params(bool fan_in, bool fan_out, Dtype n,
+      Dtype negative_slope = 0.0, Dtype scale = 1.0,
+      FillerParameter_FillerLayerType layer_type = FillerParameter_FillerLayerType_CONVOLUTION) {
     this->filler_param_.set_fan_in(fan_in);
     this->filler_param_.set_fan_out(fan_out);
+    this->filler_param_.set_scale(scale);
+    this->filler_param_.set_negative_slope(negative_slope);
+    this->filler_param_.set_layer_type(layer_type);
     this->filler_.reset(new MSRFiller<Dtype>(this->filler_param_));
-    this->filler_->Fill(blob_);
-    EXPECT_TRUE(this->blob_);
-    const int count = this->blob_->count();
-    const Dtype* data = this->blob_->cpu_data();
+
+    int count = -1;
+    const Dtype* data = NULL;
+    switch (layer_type) {
+
+      case FillerParameter_FillerLayerType_CONVOLUTION: {
+        this->filler_->Fill(blob_);
+        EXPECT_TRUE(this->blob_);
+        count = this->blob_->count();
+        data = this->blob_->cpu_data();
+        break;
+      }
+      case FillerParameter_FillerLayerType_INNER_PRODUCT: {
+        this->filler_->Fill(blob_1x1xhxw);
+        EXPECT_TRUE(this->blob_1x1xhxw);
+        count = this->blob_1x1xhxw->count();
+        data = this->blob_1x1xhxw->cpu_data();
+        break;
+      }
+      default:
+        CHECK(false) << "unspecified layer type";
+        break;
+
+    }
+
+
     const Dtype target_mean = 0.0;
-    const Dtype target_variance = 2.0 / n;
+    const Dtype target_variance =  scale * scale * (2.0 / (n * (1 + negative_slope * negative_slope)));
 
     const Dtype sample_variance_std = target_variance * sqrt(2.0/(count-1));
     //  http://en.wikipedia.org/wiki/Variance#Distribution_of_the_sample_variance
@@ -182,23 +210,77 @@ class MSRFillerTest : public ::testing::Test {
   }
   virtual ~MSRFillerTest() { delete blob_; }
   Blob<Dtype>* const blob_;
+  Blob<Dtype>* const blob_1x1xhxw;
+
   FillerParameter filler_param_;
   shared_ptr<MSRFiller<Dtype> > filler_;
 };
 
 TYPED_TEST_CASE(MSRFillerTest, TestDtypes);
 
-TYPED_TEST(MSRFillerTest, TestFillFanIn) {
-  TypeParam n = 2*4*5;
-  this->test_params(true, false, n);
-}
-TYPED_TEST(MSRFillerTest, TestFillFanOut) {
-  TypeParam n = 1000*4*5;
-  this->test_params(false, true, n);
-}
-TYPED_TEST(MSRFillerTest, TestFillFanInFanOut) {
-  TypeParam n = (2*4*5 + 1000*4*5) / 2.0;
-  this->test_params(true, true, n);
-}
+  TYPED_TEST(MSRFillerTest, TestFillFanIn) {
+    TypeParam n = 2*4*5;
+    this->test_params(true, false, n);
+  }
+  TYPED_TEST(MSRFillerTest, TestFillFanOut) {
+    TypeParam n = 1000*4*5;
+    this->test_params(false, true, n);
+  }
+  TYPED_TEST(MSRFillerTest, TestFillFanInFanOut) {
+    TypeParam n = (2*4*5 + 1000*4*5) / 2.0;
+    this->test_params(true, true, n);
+  }
+  TYPED_TEST(MSRFillerTest, TestFillFanInNegativeSlopeOne) {
+    TypeParam n = 2*4*5;
+    this->test_params(true, false, n, 1);
+  }
+  TYPED_TEST(MSRFillerTest, TestFillFanOutNegativeSlopeOne) {
+    TypeParam n = 1000*4*5;
+    this->test_params(false, true, n, 1);
+  }
+  TYPED_TEST(MSRFillerTest, TestFillFanInFanOutNegativeSlopeOne) {
+    TypeParam n = (2*4*5 + 1000*4*5) / 2.0;
+    this->test_params(true, true, n, 1);
+  }
+  TYPED_TEST(MSRFillerTest, TestFillFanInFanOutNegativeSlopeMinusOne) {
+    TypeParam n = (2*4*5 + 1000*4*5) / 2.0;
+    this->test_params(true, true, n, -1);
+  }
+  TYPED_TEST(MSRFillerTest, TestFillFanInFanOutNegativeSlopeThousand) {
+    TypeParam n = (2*4*5 + 1000*4*5) / 2.0;
+    this->test_params(true, true, n, 1000);
+  }
+
+  TYPED_TEST(MSRFillerTest, TestFillFanInFanOutNegativeSlopeMinusOneScaleTen) {
+    TypeParam n = (2*4*5 + 1000*4*5) / 2.0;
+    this->test_params(true, true, n, -1, 10);
+  }
+  TYPED_TEST(MSRFillerTest, TestFillFanInNegativeSlopeMinusOneScaleTen) {
+    TypeParam n = 2*4*5;
+    this->test_params(true, false, n, -1, 10);
+  }
+  TYPED_TEST(MSRFillerTest, TestFillFanOutNegativeSlopeMinusOneScaleTen) {
+    TypeParam n = 1000*4*5;
+    this->test_params(false, true, n, -1, 10);
+  }
+
+  TYPED_TEST(MSRFillerTest, TestFillFanInFanOutNegativeSlopeZeroOneScaleThousand) {
+    TypeParam n = (2*4*5 + 1000*4*5) / 2.0;
+    this->test_params(true, true, n, 0, 1000);
+  }
+  TYPED_TEST(MSRFillerTest, TestFillFanInFanOutNegativeSlopeMinusOneScaleTenInnerProduct) {
+    TypeParam n = (123 + 234) / 2.0;
+    this->test_params(true, true, n, -1, 10,FillerParameter_FillerLayerType_INNER_PRODUCT);
+  }
+  TYPED_TEST(MSRFillerTest, TestFillFanInNegativeSlopeMinusOneInnerProduct) {
+    TypeParam n = 123;
+    this->test_params(true, false, n, -1, 1,FillerParameter_FillerLayerType_INNER_PRODUCT);
+  }
+  TYPED_TEST(MSRFillerTest, TestFillFanOutNegativeSlopeMinusOneScaleTenInnerProduct) {
+    TypeParam n = 234;
+    this->test_params(false, true, n, -1, 10,FillerParameter_FillerLayerType_INNER_PRODUCT);
+  }
+
+
 
 }  // namespace caffe

--- a/src/caffe/test/test_filler.cpp
+++ b/src/caffe/test/test_filler.cpp
@@ -157,18 +157,28 @@ class MSRFillerTest : public ::testing::Test {
     EXPECT_TRUE(this->blob_);
     const int count = this->blob_->count();
     const Dtype* data = this->blob_->cpu_data();
-    Dtype mean = 0.;
-    Dtype ex2 = 0.;
+    const Dtype target_mean = 0.0;
+    const Dtype target_variance = 2.0 / n;
+
+    const Dtype sample_variance_std = target_variance * sqrt(2.0/(count-1));
+    //  http://en.wikipedia.org/wiki/Variance#Distribution_of_the_sample_variance
+    const Dtype sample_mean_std = sqrt(target_variance) / sqrt(count);
+    //  http://en.wikipedia.org/wiki/Standard_error
+
+    Dtype sample_mean = 0.;
+    Dtype ex2 = 0;
     for (int i = 0; i < count; ++i) {
-      mean += data[i];
+      sample_mean += data[i];
       ex2 += data[i] * data[i];
     }
-    mean /= count;
+
+
+    sample_mean /= count;
     ex2 /= count;
-    Dtype std = sqrt(ex2 - mean*mean);
-    Dtype target_std = sqrt(2.0 / n);
-    EXPECT_NEAR(mean, 0.0, 0.1);
-    EXPECT_NEAR(std, target_std, 0.1);
+    Dtype sample_variance = (ex2 - sample_mean * sample_mean) * (count / (count - 1));
+
+    EXPECT_NEAR(sample_mean, target_mean, 5 * sample_mean_std);
+    EXPECT_NEAR(sample_variance,target_variance, 5 * sample_variance_std);
   }
   virtual ~MSRFillerTest() { delete blob_; }
   Blob<Dtype>* const blob_;


### PR DESCRIPTION
Hi!
I want to collaborate in your development of MSR weight filler.

I added support for inner product layer. Current code doesn't work for ip because fan_in and fan_out are computed differently for ip and conv weight blobs.
Because ip and conv layers can have same blob dimension(100->100 ip, kernelsize = 100, in and out channels = 1, so we can't detect blob type by looking ant first 2 dimensions of blob) with different meaning, added optional FillerLayerType layer_type to FillerParameter message.

Added support for non-zero negative slope ReLU as described in original paper.

Also i added scale field to FillerParameter message.
Scale is needed in case scale of network inputs and outputs are not same ( in original paper they use scale<1 for top ip layers), or we want to manualy change amplitude of network's signal in any place.
Maybe Xavier filler also need support for this field.

Tests now expects all random variable's deviations not to exceed 5*std.
